### PR TITLE
fix: install `sox` so FS sounds are correctly overridden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN add-apt-repository -y ppa:bigbluebutton/support  \
   && apt-get update \
   && apt-get install -y \
   libopusenc-dev \
-  # sox \
+  sox \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- [fix: install sox so FS sounds are correctly overridden](https://github.com/bigbluebutton/bbb-docker-build-packages/pull/8/commits/673b1bfe7736b9a5dbfe53058962ff681c4762ee)
  - `sox` is used by the bbb-freeswitch-sounds package to reduce the volume
of Senfcall's mute/unmute sounds. Since it's installation was
deactivated due to build issues a while ago, the volume reduction step
was failing and sounds were not overwritten.
  - Install `sox` again so that FS sounds are correctly overridden.
Not sure why it was failing a while back, but it seems fine now. Tested
with a local image + a local build of bbb-freeswitch-sounds only.

Closes https://github.com/bigbluebutton/bigbluebutton/issues/20961