### PR TITLE
Create additional version only tags (without date)

### DIFF
--- a/.github/workflows/ci.build.push.yml
+++ b/.github/workflows/ci.build.push.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           push: true
           tags: |
+            "bigbluebutton/bbb-build:${{ steps.ci_branch_name.outputs.branch }}"
             "bigbluebutton/bbb-build:${{ steps.ci_branch_name.outputs.branch }}--${{ steps.date.outputs.time }}"
           context: .
           cache-from: type=gha


### PR DESCRIPTION
This commit adds a tag that only contains to the branch name (and thus the version). This tag will be overwwritten each time a new image is build for this branch. Thererfore this "version tag" will always refer to the latest build for that version.