### PR TITLE
build: pull libpcre2-dev instead of libpcre3-dev for FS@1.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update && apt-get install -y \
   libldns-dev \
   libncurses5 \
   libncurses5-dev \
-  libpcre3-dev \
+  libpcre2-dev \
   libspeexdsp-dev \
   libsqlite3-dev \
   libtool \


### PR DESCRIPTION
FreeSWITCH v1.11.0 now depends on PCRE2. 
Switch to the proper pcre dev lib required to build it.

See https://github.com/bigbluebutton/bigbluebutton/pull/25157