### PR TITLE
re-add sox for FreeSWITCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update && apt-get install -y \
 # For FreeSWITCH (libopusenc-dev is in noble's main repo, no PPA needed)
 RUN apt-get update && apt-get install -y \
   libopusenc-dev \
+  sox \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Seems I dropped it in #18 with no explanation.
Its lack is causing FS to not be able to build in 4.0: 
https://github.com/bigbluebutton/bigbluebutton/actions/runs/27712361987/job/81976374956?pr=25286
<img width="1314" height="445" alt="image" src="https://github.com/user-attachments/assets/570efa78-61fa-449a-b5ab-99cbd22eb6c8" />
