### PR TITLE
Revert "build: pull libpcre2-dev instead of libpcre3-dev for FS@1.11.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update && apt-get install -y \
   libldns-dev \
   libncurses5 \
   libncurses5-dev \
-  libpcre2-dev \
+  libpcre3-dev \
   libspeexdsp-dev \
   libsqlite3-dev \
   libtool \


### PR DESCRIPTION
Reverts bigbluebutton/bbb-docker-build-packages#20
We reverted the FS upgrade in https://github.com/bigbluebutton/bigbluebutton/pull/25273 so we should revert the docker change here. (Spotted as I am hitting issues with upgrading Go and Node https://github.com/bigbluebutton/bigbluebutton/pull/25429 because of FS not building...)